### PR TITLE
Duplicates from move

### DIFF
--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -402,17 +402,17 @@
         var dropEffect = getDropEffect(event, ignoreDataTransfer);
         if (dropEffect == 'none') return stopDragover();
 
+        // The drop is definitely going to happen now, store the dropEffect.
+        dndState.dropEffect = dropEffect;
+        if (!ignoreDataTransfer) {
+          event.dataTransfer.dropEffect = dropEffect;
+        }
+
         // Invoke the callback, which can transform the transferredObject and even abort the drop.
         var index = getPlaceholderIndex();
         if (attr.dndDrop) {
           data = invokeCallback(attr.dndDrop, event, dropEffect, itemType, index, data);
           if (!data) return stopDragover();
-        }
-
-        // The drop is definitely going to happen now, store the dropEffect.
-        dndState.dropEffect = dropEffect;
-        if (!ignoreDataTransfer) {
-          event.dataTransfer.dropEffect = dropEffect;
         }
 
         // Insert the object into the array, unless dnd-drop took care of that (returned true).


### PR DESCRIPTION
## Performing a move creates duplicate records.  

Please see example: [Plunker]( https://plnkr.co/edit/ByuIjw5pYkPQyBBuSIvq)
In the example, Re-ordering items in the **canvas** section creates duplicates. Dropping items from toolbox creates a new instance with a new id. However, moving items in the canvas section creates duplicates.

The fix can be illustrated at: [Example with solution](https://plnkr.co/edit/weSsBITt3LE9nScl6efb)
(I could not figure out how to link to repo so I pasted from source)